### PR TITLE
OLEtool fixing, streamline use and use only oletool import no py2

### DIFF
--- a/office/office/commands.py
+++ b/office/office/commands.py
@@ -20,18 +20,6 @@ from snake.utils import markdown as md
 
 app_log = logging.getLogger("tornado.application")  # pylint: disable=invalid-name
 
-
-OLEDUMP_PATH = config.scale_configs['office']['oledump_path']
-if OLEDUMP_PATH and path.isfile(OLEDUMP_PATH):
-    has_oledump = True  # pylint: disable=invalid-name
-else:
-    if OLEDUMP_PATH:
-        app_log.warning("oledump disabled - optional dependencies not met: 'oledump' not found")
-    else:
-        app_log.warning("oledump disabled - optional dependencies not met: 'oledump_path' not set")
-    has_oledump = False  # pylint: disable=invalid-name
-
-
 class Commands(scale.Commands):
     def check(self):
         pass

--- a/office/office/office.conf
+++ b/office/office/office.conf
@@ -1,2 +1,0 @@
-# Path to oledump.py
-oledump_path: null


### PR DESCRIPTION
I have implemented oletools for a variety of purposes but limited the use to the things that I thought were most useful. As vipermonkey is still py2 I have decided to implement a simpler version (mraptor)
until vipermonley py3 is availaboe or we decide to upgrade it ourselves.